### PR TITLE
Add support for deprecated fields 

### DIFF
--- a/Example/Sources/example.proto
+++ b/Example/Sources/example.proto
@@ -10,3 +10,7 @@ message AddressBook {
     repeated Person people = 1;
     optional bool is_current = 2;
 }
+
+message Address {
+    string street = 1 [deprecated = true];
+}

--- a/Example/Sources/main.swift
+++ b/Example/Sources/main.swift
@@ -4,9 +4,11 @@
 func run() {
     let person = Person(name: "John Doe", id: 1234, email: "john.doe@example.com")
     let addressBook = AddressBook(people: [person])
+    let address = Address(street: "Example Avenue")
 
     print("Name: \(person.name), ID: \(person.id), Email: \(person.email)")
     print("Address Book: \(addressBook)")
+    print("Address street: \(address.street)")
 }
 
 run()

--- a/Sources/SwiftBuffet/Generator.swift
+++ b/Sources/SwiftBuffet/Generator.swift
@@ -177,6 +177,10 @@ internal func writeProperties(
                 .joined(separator: "\n")
             output += "\n"
         }
+        if field.isDeprecated {
+            output += #"    @available(*, deprecated, message: "This property has been marked as deprecated in the proto file")"#
+            output += "\n"
+        }
         output += "    public let \(field.caseCorrectName): \(field.caseCorrectedType)\n"
     }
     if includeLocalID {

--- a/Sources/SwiftBuffet/Models.swift
+++ b/Sources/SwiftBuffet/Models.swift
@@ -35,6 +35,8 @@ struct ProtoField {
     let isRepeated: Bool
     /// Indicates if the field is a map type.
     let isMap: Bool
+    /// Indicates if the field has been marked as deprecated in the proto file.
+    let isDeprecated: Bool
 
     /// The case-corrected name of the field, converted to camelCase.
     var caseCorrectName: String {

--- a/Sources/SwiftBuffet/Parser.swift
+++ b/Sources/SwiftBuffet/Parser.swift
@@ -221,9 +221,11 @@ internal func parseMessageFields(
         let fieldModifier = match.output.3.map { String($0) }
         let fieldType = String(match.output.4)
         let fieldName = String(match.output.5)
+        let fieldOptions = match.output.6.map { String($0) }
         let isOptional = fieldModifier?.contains("optional") == true
         let isRepeated = fieldModifier?.contains("repeated") == true
         let isMap = fieldModifier?.starts(with: "map") == true
+        let isDeprecated = fieldOptions?.contains("deprecated = true") == true
         if verbose {
             print("Matched field type: \(fieldType), field name: \(fieldName), isOptional: \(isOptional), isRepeated: \(isRepeated), isMap: \(isMap))")
         }
@@ -235,7 +237,8 @@ internal func parseMessageFields(
                 comment: comment,
                 isOptional: isOptional,
                 isRepeated: isRepeated,
-                isMap: isMap
+                isMap: isMap,
+                isDeprecated: isDeprecated
             )
         )
     }

--- a/Sources/SwiftBuffet/Regex.swift
+++ b/Sources/SwiftBuffet/Regex.swift
@@ -8,7 +8,7 @@ let enumPattern =
 #/enum\s+(\w+)\s*\{([\s\S]*?)\n?\}/#
 
 let fieldPattern = 
-#/\s*(\/\*\*(.|\n)*?\*\/)?\s*(optional|repeated|map)?\s*(\s*<\s*\w+\s*,\s*\w+\s*>|[\w\.]+)\s+(\w+)\s*=\s*\d+;/#
+#/\s*(\/\*\*(.|\n)*?\*\/)?\s*(optional|repeated|map)?\s*(\s*<\s*\w+\s*,\s*\w+\s*>|[\w\.]+)\s+(\w+)\s*=\s*\d+\s*(\[deprecated = .*\])?;/#
 
 let enumCasePattern = 
 #/\s*(\w+)\s*=\s*(\d+);/#

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -13,7 +13,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -22,7 +23,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -31,7 +33,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 )
             ],
             parentName: nil
@@ -72,7 +75,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -81,7 +85,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -90,7 +95,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 )
             ],
             parentName: nil
@@ -106,7 +112,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -115,7 +122,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -124,7 +132,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 )
             ],
             parentName: nil
@@ -167,7 +176,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -176,7 +186,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -185,7 +196,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -194,7 +206,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -203,7 +216,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 ),
                 ProtoField(
                     swiftPrefix: "App",
@@ -212,7 +226,8 @@ final class GeneratorTests: XCTestCase {
                     comment: nil,
                     isOptional: false,
                     isRepeated: false,
-                    isMap: false
+                    isMap: false,
+                    isDeprecated: false
                 )
             ],
             parentName: nil


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
In a recent update to the Blueprint models, some fields were marked as deprecated - see [here](https://github.com/guardian/ios-live/pull/8161). 
This PR updates the parser logic to first recognise fields as deprecated and then secondly, if a field is deprecated use Swift availability checking so that it gets marked as deprecated in Swift and flagged with a warning. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
You can use the Example project included as part of this repo you'll be able to verify that the deprecated example that's been added creates a warning as expected. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
