### PR TITLE
Deprecation - replace warnings with comment

### DIFF
--- a/Sources/SwiftBuffet/Generator.swift
+++ b/Sources/SwiftBuffet/Generator.swift
@@ -178,7 +178,7 @@ internal func writeProperties(
             output += "\n"
         }
         if field.isDeprecated {
-            output += #"    @available(*, deprecated, message: "This property has been marked as deprecated in the proto file")"#
+            output += #"/// This property has been marked as **deprecated** in the proto file"#
             output += "\n"
         }
         output += "    public let \(field.caseCorrectName): \(field.caseCorrectedType)\n"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR removes deprecation warnings due to the fact warnings would be raised in the blueprint.swift file within the dependent project. 
Instead of using a compiler deprecation warning, this PR adds a markdown comment to the deprecated properties instead to flag them as deprecated more quietly. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
Run the Example project and see the deprecation warning for `Addreess.street` is removed and the generated `Address` struct has a comment next to the street property.  
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![Screenshot 2024-09-20 at 11 00 37](https://github.com/user-attachments/assets/9a7ee4af-13cb-45e0-9b54-3cbf07ca8955)
![Screenshot 2024-09-20 at 11 00 45](https://github.com/user-attachments/assets/d856aec4-c08c-4048-af06-0553f38791a6)
![Screenshot 2024-09-20 at 11 01 05](https://github.com/user-attachments/assets/094b8b5d-3a5a-494f-bed0-4069a23557fb)

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
