### PR TITLE
Remove default values from basic initialiser 

### DIFF
--- a/Example/Sources/main.swift
+++ b/Example/Sources/main.swift
@@ -3,7 +3,7 @@
 
 func run() {
     let person = Person(name: "John Doe", id: 1234, email: "john.doe@example.com")
-    let addressBook = AddressBook(people: [person])
+    let addressBook = AddressBook(people: [person], isCurrent: false)
     let address = Address(street: "Example Avenue")
 
     print("Name: \(person.name), ID: \(person.id), Email: \(person.email)")

--- a/Sources/SwiftBuffet/Generator.swift
+++ b/Sources/SwiftBuffet/Generator.swift
@@ -209,13 +209,11 @@ internal func writeBasicInit(for message: ProtoMessage, to output: inout String)
     } else {
         for field in fields {
             output += "         \(field.caseCorrectName): \(field.caseCorrectedType)"
-            writeDefaultValue(for: field, to: &output)
             output += ",\n"
         }
 
         if let field = last {
             output += "         \(field.caseCorrectName): \(field.caseCorrectedType)"
-            writeDefaultValue(for: field, to: &output)
             output += "\n"
         }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR removes the default values from the basic initialiser function. This is important so that as properties are added to the models, they are not missed when directly initialising the object. 
Although this would mean the initialisation function will need to be more verbose, it will ensure properties are all correctly initialised. 

You can see an example in the iOS live repo where this caused problems - https://github.com/guardian/ios-live/pull/8207. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
I have tested this using the example project in the repo - you can see now that the `AddressBook` initialiser requires the value `isCurrent` to be set. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
