### PR TITLE
Support a list of local ID messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ In addition to the basic input and output paths, Swift Buffet provides several o
   }
   ```
 
-- `--use-local-ids`: This option is enabled by default and adds local IDs to the generated Swift objects, which can be particularly helpful in SwiftUI-based apps. To disable this feature:
+- `--local-id-messages`: This option allows the user to specify which, if any, messages should include local IDs in their generated Swift objects. This can be particularly helpful in SwiftUI-based apps. 
 
   ```bash
-  swift run SwiftBuffet path/to/your/file.proto path/to/your/output.swift --use-local-ids false
+  swift run SwiftBuffet path/to/your/file.proto path/to/your/output.swift --local-id-messages Person --local-id-messages Dog
   ```
 
   ```swift

--- a/Sources/SwiftBuffet/Generator.swift
+++ b/Sources/SwiftBuffet/Generator.swift
@@ -11,7 +11,7 @@ func generateSwiftCode(
     enums: [ProtoEnum],
     with swiftPrefix: String,
     includeProto: Bool,
-    includeLocalID: Bool,
+    includeLocalIDFor localIDMessages: [String]?,
     includeBackingData: Bool,
     with protoPrefix: String
 ) -> String {
@@ -22,7 +22,7 @@ func generateSwiftCode(
         to: &output,
         with: swiftPrefix,
         includeProto: includeProto,
-        includeLocalID: includeLocalID,
+        includeLocalIDFor: localIDMessages,
         includeBackingData: includeBackingData,
         with: protoPrefix
     )
@@ -115,7 +115,7 @@ internal func write(
     to output: inout String,
     with swiftPrefix: String,
     includeProto: Bool,
-    includeLocalID: Bool,
+    includeLocalIDFor messageNames: [String]?,
     includeBackingData: Bool,
     with protoPrefix: String
 ) {
@@ -128,7 +128,7 @@ internal func write(
 
         writeProperties(
             for: message,
-            includeLocalID: includeLocalID,
+            includeLocalID: messageNames?.contains(message.name) ?? false,
             includeBackingData: includeBackingData,
             to: &output
         )

--- a/Sources/SwiftBuffet/main.swift
+++ b/Sources/SwiftBuffet/main.swift
@@ -33,10 +33,10 @@ struct SwiftBuffet: ParsableCommand {
     var storeBackingData: Bool = false
 
     @Option(
-        name: .customLong("use-local-ids"),
-        help: "Add a local ID to protobuf objects, can be useful in SwiftUI"
+        name: .customLong("local-id-messages"),
+        help: "A list of message name describing which objects should include a local ID. This can be useful in SwiftUI"
     )
-    var useLocalIDS: Bool = true
+    var localIDMessages: [String] = []
 
     @Flag(name: .shortAndLong, help: "Show all logging")
     var verbose: Bool = false
@@ -64,7 +64,7 @@ struct SwiftBuffet: ParsableCommand {
             enums: enums,
             with: swiftPrefix,
             includeProto: includeProtobuf,
-            includeLocalID: useLocalIDS,
+            includeLocalIDFor: localIDMessages,
             includeBackingData: storeBackingData,
             with: protoPrefix
         )

--- a/Tests/GeneratorTests.swift
+++ b/Tests/GeneratorTests.swift
@@ -48,7 +48,7 @@ final class GeneratorTests: XCTestCase {
             enums: enums,
             with: "App",
             includeProto: true,
-            includeLocalID: false,
+            includeLocalIDFor: ["Person"],
             includeBackingData: false,
             with: "Proto"
         )
@@ -62,6 +62,7 @@ final class GeneratorTests: XCTestCase {
         XCTAssertTrue(generatedCode.contains("self.age = age"), "The generated code should initialize the 'age' property")
         XCTAssertTrue(generatedCode.contains("self.isActive = isActive"), "The generated code should initialize the 'isActive' property")
         XCTAssertTrue(generatedCode.contains("internal init?(proto: ProtoPerson)"), "The generated code should contain the 'init?(proto:)' method")
+        XCTAssertTrue(generatedCode.contains("public let _localID = UUID()"), "The generated code should a `localID` property")
     }
 
     func testGenerateNestedMessage() {
@@ -147,7 +148,7 @@ final class GeneratorTests: XCTestCase {
             enums: enums,
             with: "App",
             includeProto: true,
-            includeLocalID: false,
+            includeLocalIDFor: nil,
             includeBackingData: false,
             with: "Proto"
         )
@@ -251,7 +252,7 @@ final class GeneratorTests: XCTestCase {
             enums: enums,
             with: "App",
             includeProto: true,
-            includeLocalID: false,
+            includeLocalIDFor: nil,
             includeBackingData: false,
             with: "Proto"
         )
@@ -268,5 +269,62 @@ final class GeneratorTests: XCTestCase {
         XCTAssertTrue(generatedCode.contains("public let lastActive: TimeInterval"), "The generated code should contain the 'lastActive' property")
         XCTAssertTrue(generatedCode.contains("public let createdAt: Date"), "The generated code should contain the 'createdAt' property")
         XCTAssertTrue(generatedCode.contains("internal init?(proto: ProtoPerson)"), "The generated code should contain the 'init?(proto:)' method")
+    }
+
+    func testLocalIDs() {
+        let simpleMessageProtoMessage = ProtoMessage(
+            name: "Person",
+            fields: [
+                ProtoField(
+                    swiftPrefix: "App",
+                    name: "name",
+                    type: "string",
+                    comment: nil,
+                    isOptional: false,
+                    isRepeated: false,
+                    isMap: false,
+                    isDeprecated: false
+                )
+            ],
+            parentName: nil
+        )
+
+        let simpleMessageProtoMessageNoLocalID = ProtoMessage(
+            name: "Dog",
+            fields: [
+                ProtoField(
+                    swiftPrefix: "App",
+                    name: "breed",
+                    type: "string",
+                    comment: nil,
+                    isOptional: false,
+                    isRepeated: false,
+                    isMap: false,
+                    isDeprecated: false
+                )
+            ],
+            parentName: nil
+        )
+
+
+        let messages = [simpleMessageProtoMessage, simpleMessageProtoMessageNoLocalID]
+        let enums: [ProtoEnum] = []
+
+        let generatedCode = generateSwiftCode(
+            from: messages,
+            enums: enums,
+            with: "App",
+            includeProto: true,
+            includeLocalIDFor: ["Person"],
+            includeBackingData: false,
+            with: "Proto"
+        )
+
+        func containsExactlyOneInstance(of substring: String, in string: String) -> Bool {
+            let components = string.components(separatedBy: substring)
+            return components.count == 2
+        }
+
+        XCTAssert(containsExactlyOneInstance(of: "public let _localID = UUID()", in: generatedCode))
     }
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR changes the `use-local-ids` flag to a parameter (`--local-id-messages`) that takes one or more message names, describing which should include a local ID in their generated Swift objects. 

## How to test

I have tested this by running the tool locally, and could verify that the `localID` was only added to the messages specified with `--local-id-messages`. I also added a unit test to verify this.
