### PR TITLE
Add support for unrecognized case in enums 

### DIFF
--- a/Example/Sources/example.proto
+++ b/Example/Sources/example.proto
@@ -14,3 +14,14 @@ message AddressBook {
 message Address {
     string street = 1 [deprecated = true];
 }
+
+message Card {
+    enum CardType {
+        CARD_TYPE_UNSPECIFIED = 0;
+        CARD_TYPE_ARTICLE = 1;
+        CARD_TYPE_PODCAST = 2;
+        CARD_TYPE_VIDEO = 3;
+        CARD_TYPE_CROSSWORD = 4;
+    }
+    CardType type = 1;
+}

--- a/Sources/SwiftBuffet/Generator.swift
+++ b/Sources/SwiftBuffet/Generator.swift
@@ -65,13 +65,17 @@ internal func write(
         }
 
         output += "public enum \(swiftPrefix)\(protoEnum.name): Int, CaseIterable, Hashable, Equatable, Sendable {\n"
-
+        var finalCaseValue = 0
         for (caseName, caseValue) in pair {
             if protoEnum.parentName != nil {
                 output += "    "
             }
             output += "    case \(caseName) = \(caseValue)\n"
+            finalCaseValue = caseValue
         }
+        // Add unrecognized case for backwards compatibility
+        let unrecognizedCaseValue = finalCaseValue + 1
+        output += "        case unrecognized = \(unrecognizedCaseValue)\n"
         if includeProto {
             writeEnumProtoInit(
                 for: protoEnum,

--- a/Sources/SwiftBuffet/Generator.swift
+++ b/Sources/SwiftBuffet/Generator.swift
@@ -103,8 +103,13 @@ internal func writeEnumProtoInit(for protoEnum: ProtoEnum, to output: inout Stri
     } else {
         ""
     }
-    output += padding + "    internal init?(proto: \(protoPrefix)\(protoEnum.fullName)) {\n"
-    output += padding + "        self.init(rawValue: proto.rawValue)\n"
+
+    output += padding + "    internal init(proto: \(protoPrefix)\(protoEnum.fullName)) {\n"
+    output += padding + "        if let value = Self(rawValue: proto.rawValue) {\n"
+    output += padding + "            self = value\n"
+    output += padding + "        } else {\n"
+    output += padding + "            self = .unrecognized\n"
+    output += padding + "        }\n"
     output += padding + "    }\n"
 }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR introduces a new `unrecognized` case for enums with the goal being that the apps should be able to be backwards compatible and the addition of new cases in an enum shouldn't be a breaking change. 
Currently, if a new case is added to an enum existing versions of the app which do not have knowledge of that case will simply not render the card since the intialiser was failable. 
This change uses the `unrecognized` case - if an additional enum case is added - app versions without knowledge of that case will default to use the `unrecognized` case and the app can decide how it wants to handle it. 

Changes: 
1. New `unrecognised` case in all enums 
2. Updated initialiser to be non-failable and instead revert to using the `unrecognised` case

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
You can test this locally by running the example project and observing that the `example.swift` file contains the CardType enum with the unrecognized case at the end. 
<img width="1134" alt="Screenshot 2025-01-07 at 16 07 51" src="https://github.com/user-attachments/assets/73730a1d-d024-40b6-89b2-abbe73579a99" />
To test that the initialiser is as we expect you will need to change `includeProtobuf` to true within the `main.swift` file - however, I haven't committed that change since it breaks the example due to the addition of the "Proto" prefix on the models. 
But you can see the initialiser is generated to handle the failure from initialising with a raw value.  
<img width="1134" alt="Screenshot 2025-01-07 at 16 10 04" src="https://github.com/user-attachments/assets/6e728f41-f259-4b7a-a8e5-4a8b058c23b0" />

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
