### PR TITLE
Revert "Add support for unrecognized case in enums "

### DIFF
--- a/Example/Sources/example.proto
+++ b/Example/Sources/example.proto
@@ -14,14 +14,3 @@ message AddressBook {
 message Address {
     string street = 1 [deprecated = true];
 }
-
-message Card {
-    enum CardType {
-        CARD_TYPE_UNSPECIFIED = 0;
-        CARD_TYPE_ARTICLE = 1;
-        CARD_TYPE_PODCAST = 2;
-        CARD_TYPE_VIDEO = 3;
-        CARD_TYPE_CROSSWORD = 4;
-    }
-    CardType type = 1;
-}

--- a/Sources/SwiftBuffet/Generator.swift
+++ b/Sources/SwiftBuffet/Generator.swift
@@ -65,17 +65,13 @@ internal func write(
         }
 
         output += "public enum \(swiftPrefix)\(protoEnum.name): Int, CaseIterable, Hashable, Equatable, Sendable {\n"
-        var finalCaseValue = 0
+
         for (caseName, caseValue) in pair {
             if protoEnum.parentName != nil {
                 output += "    "
             }
             output += "    case \(caseName) = \(caseValue)\n"
-            finalCaseValue = caseValue
         }
-        // Add unrecognized case for backwards compatibility
-        let unrecognizedCaseValue = finalCaseValue + 1
-        output += "        case unrecognized = \(unrecognizedCaseValue)\n"
         if includeProto {
             writeEnumProtoInit(
                 for: protoEnum,
@@ -103,13 +99,8 @@ internal func writeEnumProtoInit(for protoEnum: ProtoEnum, to output: inout Stri
     } else {
         ""
     }
-
-    output += padding + "    internal init(proto: \(protoPrefix)\(protoEnum.fullName)) {\n"
-    output += padding + "        if let value = Self(rawValue: proto.rawValue) {\n"
-    output += padding + "            self = value\n"
-    output += padding + "        } else {\n"
-    output += padding + "            self = .unrecognized\n"
-    output += padding + "        }\n"
+    output += padding + "    internal init?(proto: \(protoPrefix)\(protoEnum.fullName)) {\n"
+    output += padding + "        self.init(rawValue: proto.rawValue)\n"
     output += padding + "    }\n"
 }
 


### PR DESCRIPTION
Reverts guardian/swift-buffet#6

The original PR breaks the iOS app's integration with the Swift Buffet library and so needs to be reverted until we can find a way to make fix the initialiser logic. 
The PR updates so how unrecognized cases are handled in enums by removing the failable initialiser and defaulting to a new `unrecognized` case, the desire was that the app could better handle the scenario in which new types are added to the model. 

Introduces this error and so further work is needed to update the initialisation logic elsewhere, unfortunately I don't have time to fix this so it's a clean revert for now. 
<img width="891" alt="Screenshot 2025-02-13 at 15 28 44" src="https://github.com/user-attachments/assets/5e506439-0a37-45ce-801e-fde62a051ec7" />

